### PR TITLE
Set maven-compiler-plugin version to 3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+		<version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>


### PR DESCRIPTION
because setting no version could result in a broken build in the future.